### PR TITLE
Add xmlns for XSL insertion to TEI doc

### DIFF
--- a/bibliophilly-keywords.xml
+++ b/bibliophilly-keywords.xml
@@ -1,4 +1,4 @@
-<encodingDesc>
+<encodingDesc xmlns="http://www.tei-c.org/ns/1.0">
 <classDecl>
 <taxonomy xml:id="keywords">
 <category xml:id="keyword_1">


### PR DESCRIPTION
Hi Dot,
I ran into an issue inserting the content of this file. Saxon was creating a blank namespace `<encodingDesc xmlns="">`. To fix it, I've added the TEI namespace to the encodingDesc in the XML fragment. I'm not sure if this is the best way to address the problem. Here's how I'm doing the insertion:

```xml
<xsl:copy-of select="document('/path/to/bibliophilly-keywords/bibliophilly-keywords.xml')"/>
```

